### PR TITLE
fix: allow 'self' scripts for csp

### DIFF
--- a/docker/etc/nginx/custom/headers.conf
+++ b/docker/etc/nginx/custom/headers.conf
@@ -1,5 +1,5 @@
 # Add security headers.
-add_header Content-Security-Policy "worker-src 'self' blob:; script-src 'unsafe-inline'; img-src 'self' data: https:; font-src https: fonts.googleapis.com; report-uri /report-csp-violation; upgrade-insecure-requests";
+add_header Content-Security-Policy "worker-src 'self' blob:; script-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src https: fonts.googleapis.com; report-uri /report-csp-violation; upgrade-insecure-requests";
 add_header Referrer-Policy "strict-origin-when-cross-origin";
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload; always;";
 add_header X-Content-Options "nosniff";


### PR DESCRIPTION
Refs: OPS-10268

Not sure if this nginx config is being used in production but it appears to be. The csp config we're using elsewhere is listed at https://docs.google.com/spreadsheets/d/1aJtXMCckhxRSLaMToBS37nwd9XLWeGdtD1rOAbXI7jc/edit#gid=0 With the other sites, we're only reporting csp exceptions, not actually blocking anything.