### PR TITLE
chore: fix test action by giving it appropriate permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,13 +2,16 @@ name: Run tests
 
 on: [pull_request]
 
-permissions:
-  contents: write
-
 jobs:
   tests:
     name: Run tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
+      pull-requests: write
+      actions: read
+      statuses: write
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,9 @@ name: Run tests
 
 on: [pull_request]
 
+permissions:
+  contents: write
+
 jobs:
   tests:
     name: Run tests


### PR DESCRIPTION
An attempt to fix https://github.com/UN-OCHA/ocha-api-site/actions/runs/10797377121/job/29991357544:
```
Run slavcodev/coverage-monitor-action@v1
Error: Resource not accessible by integration
```
as suggested in https://stackoverflow.com/a/77809124