### PR TITLE
chore(security): Build the same API site on a current docker image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/unocha/php-k8s:8.2-stable as builder
+FROM public.ecr.aws/unocha/php-k8s:8.2-develop as builder
 ARG  BRANCH_ENVIRONMENT
 ENV  APP_ENV=PROD \
      PUBLIC_DIR=/srv/www/public \
@@ -9,7 +9,7 @@ WORKDIR /srv/www
 RUN composer install --no-scripts --prefer-dist --optimize-autoloader && \
     bin/console assets:install public
 
-FROM public.ecr.aws/unocha/php-k8s:8.2-stable
+FROM public.ecr.aws/unocha/php-k8s:8.2-develop
 
 ARG VCS_REF
 ARG VCS_URL


### PR DESCRIPTION
So that scout stops reporting it as being Alpine 3.19 based. Brrrr.

Refs: OPS-11599